### PR TITLE
infra: clickhouse gateway

### DIFF
--- a/README_LINER.md
+++ b/README_LINER.md
@@ -1,0 +1,10 @@
+### Modifications from upstream([langfuse/langfuse-k8s](https://github.com/langfuse/langfuse-k8s))
+
+- set k8s Gateway, GCPGatewayPolicy, HTTPRoute for internal access through [langfuse-v3.getliner.com](https://langfuse-v3.getliner.com/)
+- setup connection parameters for Cloud SQL postgres, Memorystore redis, GCS
+- deployed ClickHouse on k8s with ClickHouse Keeper(`keeper.enabled=true`) instead of default Zookeeper with custom storageclass `standard-rwo-retain`(pd-balanced(SSD) with `reclaimPolicy: Retain`) along with internal access through http://langfuse-clickhouse.getliner.com:80
+
+### Upgrading helm chart
+
+1. Check k8s context set to `linerva` cluster (`gcloud container clusters get-credentials linerva --region=us-central1-c`)
+2. `helm upgrade -n langfuse-v3 langfuse ./charts/langfuse`

--- a/charts/langfuse/templates/clickhouse-gateway-policy.yaml
+++ b/charts/langfuse/templates/clickhouse-gateway-policy.yaml
@@ -1,0 +1,11 @@
+kind: GCPGatewayPolicy
+apiVersion: networking.gke.io/v1
+metadata:
+  name: langfuse-clickhouse-gateway-policy
+spec:
+  default:
+    allowGlobalAccess: true
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: langfuse-clickhouse-gateway

--- a/charts/langfuse/templates/clickhouse-gateway.yaml
+++ b/charts/langfuse/templates/clickhouse-gateway.yaml
@@ -1,0 +1,13 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: langfuse-clickhouse-gateway
+spec:
+  gatewayClassName: gke-l7-rilb
+  addresses:
+    - type: NamedAddress
+      value: langfuse-clickhouse-static-ip
+  listeners:
+    - name: clickhouse
+      protocol: HTTP
+      port: 80

--- a/charts/langfuse/templates/clickhouse-http-route.yaml
+++ b/charts/langfuse/templates/clickhouse-http-route.yaml
@@ -1,0 +1,14 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: langfuse-clickhouse-http-route
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: langfuse-clickhouse-gateway
+  hostnames:
+    - "langfuse-clickhouse.getliner.com"
+  rules:
+    - backendRefs:
+        - name: langfuse-clickhouse
+          port: 8123


### PR DESCRIPTION
Setup k8s gateway for clickhouse linked to `http://langfuse-clickhouse.getliner.com:80`